### PR TITLE
Prevent SNI errors due to host header in prod

### DIFF
--- a/src/apollo/client.js
+++ b/src/apollo/client.js
@@ -7,6 +7,10 @@ import withApollo from './WithApollo';
 const config = (req) => {
   const headers = req ? req.headers : {};
   const host = (req) ? req.ROOT_URI : '';
+  if (headers.host) {
+    headers['x-forwarded-host'] = headers.host;
+    delete headers.host;
+  }
   return {
     link: ApolloLink.from([
       onError(({ graphQLErrors, networkError }) => {


### PR DESCRIPTION
When HTTP requests are received the `Host` header overrides the domain actually being accessed. Since the production `ROOT_URI` (https://acbm.native-x.io) does not contain client-specific SSL certs, this causes a SNI 503 error when attempting to use the root application certificate for the forwarded hostname.

For example, accessing the page at `https://stories.firehouse.com` will send a request to the GraphQL server at the configured `ROOT_URI` (https://ebm.native-x.io/graph) with the `Host: stories.firehouse.com` header, for which there is no certificate on the `nx-graph` core balancer.

Relative requests to the `/graph` endpoint from the browser will still fall back to the default value for the host, which will hit the proper load balancer and have SSL terminated properly.